### PR TITLE
Added Warnings as errors control to CMakeLists

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,8 +30,11 @@ install(
 )
 
 install(TARGETS
-${PROJECT_NAME}
-  DESTINATION lib/${PROJECT_NAME})
+  ${PROJECT_NAME}
+  DESTINATION lib/${PROJECT_NAME}
+)
+
+target_compile_options(${PROJECT_NAME} PUBLIC -Wall -Wextra -Wpedantic -Werror)
 
 ament_target_dependencies(${PROJECT_NAME} rclcpp sonia_common_cpp sonia_common_ros2 sensor_msgs std_srvs)
 

--- a/src/NortekDVL.cpp
+++ b/src/NortekDVL.cpp
@@ -45,6 +45,7 @@ namespace dvl_port_manager
 
     void NortekDVL::_tare_depth(const std::shared_ptr<std_srvs::srv::Trigger::Request> request, std::shared_ptr<std_srvs::srv::Trigger::Response> response)
     {
+        (void)request; // ignore param
         _depthOffset = _dvlData.data.pressure;
         response->success=true;
         response->message="Depth Sensor tared";


### PR DESCRIPTION
Updated CMake to set warnings as errors for QoL.

## Modified Files
- CMakeLists.txt:
  - Added warnins as errors.
- src/NortekDVL.cpp:
  - Fixed unused warning.