### PR TITLE
Loss bug

### DIFF
--- a/include/dvl_port_manager/PathfinderDVL.hpp
+++ b/include/dvl_port_manager/PathfinderDVL.hpp
@@ -11,7 +11,7 @@ namespace dvl_port_manager
     {
     public:
         PathfinderDVL();
-        ~PathfinderDVL(){};
+        ~PathfinderDVL();
 
     protected:
         void receiveDataThread() override;

--- a/src/DVLProvider.cpp
+++ b/src/DVLProvider.cpp
@@ -23,6 +23,9 @@ namespace dvl_port_manager
     
     DVLProvider::~DVLProvider()
     {
+        if(_receiveThread.joinable()){
+            _receiveThread.join();
+        }  
     }
 
 } // namespace dvl_port_manager

--- a/src/DVLProvider.cpp
+++ b/src/DVLProvider.cpp
@@ -23,6 +23,8 @@ namespace dvl_port_manager
     
     DVLProvider::~DVLProvider()
     {
+        if(_receiveThread.joinable())
+            _receiveThread.join();
     }
 
 } // namespace dvl_port_manager

--- a/src/DVLProvider.cpp
+++ b/src/DVLProvider.cpp
@@ -23,8 +23,6 @@ namespace dvl_port_manager
     
     DVLProvider::~DVLProvider()
     {
-        if(_receiveThread.joinable())
-            _receiveThread.join();
     }
 
 } // namespace dvl_port_manager

--- a/src/NortekDVL.cpp
+++ b/src/NortekDVL.cpp
@@ -10,7 +10,7 @@ namespace dvl_port_manager
     {
         //Setting Quality of service policy
         rclcpp::QoS qos_pub_info(10);
-        qos_pub_info.reliability(rclcpp::ReliabilityPolicy::BestEffort);
+        qos_pub_info.reliability(rclcpp::ReliabilityPolicy::Reliable);
         
         //publishers
         _publisherSpeed = this->create_publisher<sonia_common_ros2::msg::BodyVelocityDVL>("/provider_dvl/dvl_velocity", qos_pub_info);

--- a/src/NortekDVL.cpp
+++ b/src/NortekDVL.cpp
@@ -8,11 +8,14 @@ namespace dvl_port_manager
     NortekDVL::NortekDVL()
         : DVLProvider("192.168.0.12", 9002, 0, sizeof(NortekFormat_t)), _depthOffset{}
     {
+        //Setting Quality of service policy
+        rclcpp::QoS qos_pub_info(10);
+        qos_pub_info.reliability(rclcpp::ReliabilityPolicy::BestEffort).durability(rclcpp::DurabilityPolicy::Volatile).history(rclcpp::HistoryPolicy::KeepLast);
         
-        _publisherSpeed = this->create_publisher<sonia_common_ros2::msg::BodyVelocityDVL>("/provider_dvl/dvl_velocity", 10);
-        _publisherFluidPressure = this->create_publisher<sensor_msgs::msg::FluidPressure>("/provider_dvl/dvl_pressure", 10);
-        _publisherTemperature = this->create_publisher<sensor_msgs::msg::Temperature>("/provider_dvl/dvl_water_temperature", 10);
-        _publisherRelativeDepth = this->create_publisher<std_msgs::msg::Float32>("/provider_depth/depth", 10);
+        _publisherSpeed = this->create_publisher<sonia_common_ros2::msg::BodyVelocityDVL>("/provider_dvl/dvl_velocity", qos_pub_info);
+        _publisherFluidPressure = this->create_publisher<sensor_msgs::msg::FluidPressure>("/provider_dvl/dvl_pressure", qos_pub_info);
+        _publisherTemperature = this->create_publisher<sensor_msgs::msg::Temperature>("/provider_dvl/dvl_water_temperature", qos_pub_info);
+        _publisherRelativeDepth = this->create_publisher<std_msgs::msg::Float32>("/provider_depth/depth", qos_pub_info);
 
         _tare_srv = this->create_service<std_srvs::srv::Trigger>("/provider_depth/tare", std::bind(&NortekDVL::_tare_depth, this, _1, _2));
 

--- a/src/NortekDVL.cpp
+++ b/src/NortekDVL.cpp
@@ -10,8 +10,9 @@ namespace dvl_port_manager
     {
         //Setting Quality of service policy
         rclcpp::QoS qos_pub_info(10);
-        qos_pub_info.reliability(rclcpp::ReliabilityPolicy::BestEffort).durability(rclcpp::DurabilityPolicy::Volatile).history(rclcpp::HistoryPolicy::KeepLast);
+        qos_pub_info.reliability(rclcpp::ReliabilityPolicy::BestEffort);
         
+        //publishers
         _publisherSpeed = this->create_publisher<sonia_common_ros2::msg::BodyVelocityDVL>("/provider_dvl/dvl_velocity", qos_pub_info);
         _publisherFluidPressure = this->create_publisher<sensor_msgs::msg::FluidPressure>("/provider_dvl/dvl_pressure", qos_pub_info);
         _publisherTemperature = this->create_publisher<sensor_msgs::msg::Temperature>("/provider_dvl/dvl_water_temperature", qos_pub_info);

--- a/src/NortekDVL.cpp
+++ b/src/NortekDVL.cpp
@@ -8,6 +8,7 @@ namespace dvl_port_manager
     NortekDVL::NortekDVL()
         : DVLProvider("192.168.0.12", 9002, 0, sizeof(NortekFormat_t)), _depthOffset{}
     {
+        
         _publisherSpeed = this->create_publisher<sonia_common_ros2::msg::BodyVelocityDVL>("/provider_dvl/dvl_velocity", 10);
         _publisherFluidPressure = this->create_publisher<sensor_msgs::msg::FluidPressure>("/provider_dvl/dvl_pressure", 10);
         _publisherTemperature = this->create_publisher<sensor_msgs::msg::Temperature>("/provider_dvl/dvl_water_temperature", 10);

--- a/src/PathfinderDVL.cpp
+++ b/src/PathfinderDVL.cpp
@@ -10,10 +10,10 @@ namespace dvl_port_manager
     {
         //Setting Quality of service policy
         rclcpp::QoS qos_pub_info(10);
-        qos_pub_info.reliability(rclcpp::ReliabilityPolicy::BestEffort).durability(rclcpp::DurabilityPolicy::Volatile).history(rclcpp::HistoryPolicy::KeepLast);
+        qos_pub_info.reliability(rclcpp::ReliabilityPolicy::BestEffort);
 
         rclcpp::QoS qos_sub_info(1);
-        qos_sub_info.reliability(rclcpp::ReliabilityPolicy::Reliable).durability(rclcpp::DurabilityPolicy::Volatile);
+        qos_sub_info.reliability(rclcpp::ReliabilityPolicy::Reliable);
 
         _publisherBodyVelocity = this->create_publisher<sonia_common_ros2::msg::BodyVelocityDVL>("/provider_dvl/dvl_velocity", qos_pub_info);
         _publisherLeakSensor = this->create_publisher<std_msgs::msg::Bool>("/provider_dvl/dvl_leak_sensor", qos_pub_info);

--- a/src/PathfinderDVL.cpp
+++ b/src/PathfinderDVL.cpp
@@ -42,7 +42,6 @@ namespace dvl_port_manager
         while (rclcpp::ok())
         {
             _socket.ReceiveUDP();
-            RCLCPP_DEBUG(this->get_logger(), "Data Received");
 
             getData<PathfinderFormat_t>(_dvlData);
 

--- a/src/PathfinderDVL.cpp
+++ b/src/PathfinderDVL.cpp
@@ -13,7 +13,7 @@ namespace dvl_port_manager
         qos_pub_info.reliability(rclcpp::ReliabilityPolicy::BestEffort).durability(rclcpp::DurabilityPolicy::Volatile).history(rclcpp::HistoryPolicy::KeepLast);
 
         rclcpp::QoS qos_sub_info(1);
-        qos_sub_info.reliability(rclcpp::ReliabilityPolicy::Reliable).durability(rclcpp::DurabilityPolicy::TransientLocal);
+        qos_sub_info.reliability(rclcpp::ReliabilityPolicy::Reliable).durability(rclcpp::DurabilityPolicy::Volatile);
 
         _publisherBodyVelocity = this->create_publisher<sonia_common_ros2::msg::BodyVelocityDVL>("/provider_dvl/dvl_velocity", qos_pub_info);
         _publisherLeakSensor = this->create_publisher<std_msgs::msg::Bool>("/provider_dvl/dvl_leak_sensor", qos_pub_info);

--- a/src/PathfinderDVL.cpp
+++ b/src/PathfinderDVL.cpp
@@ -8,12 +8,16 @@ namespace dvl_port_manager
     PathfinderDVL::PathfinderDVL()
         : DVLProvider("192.168.0.32", 1033, 1035, sizeof(PathfinderFormat_t))
     {
-        rclcpp::QoS qos(10);
-        qos.reliable();
+        //Setting Quality of service policy
+        rclcpp::QoS qos_pub_info(10);
+        qos_pub_info.reliability(rclcpp::ReliabilityPolicy::BestEffort).durability(rclcpp::DurabilityPolicy::Volatile).history(rclcpp::HistoryPolicy::KeepLast);
 
-        _publisherBodyVelocity = this->create_publisher<sonia_common_ros2::msg::BodyVelocityDVL>("/provider_dvl/dvl_velocity", qos);
-        _publisherLeakSensor = this->create_publisher<std_msgs::msg::Bool>("/provider_dvl/dvl_leak_sensor", qos);
-        _subscriptionEnableDisableDVL = this->create_subscription<std_msgs::msg::Bool>("/provider_dvl/enable_disable_dvl", 10, std::bind(&PathfinderDVL::_enableDisableDVL, this, _1));
+        rclcpp::QoS qos_sub_info(1);
+        qos_sub_info.reliability(rclcpp::ReliabilityPolicy::Reliable).durability(rclcpp::DurabilityPolicy::TransientLocal);
+
+        _publisherBodyVelocity = this->create_publisher<sonia_common_ros2::msg::BodyVelocityDVL>("/provider_dvl/dvl_velocity", qos_pub_info);
+        _publisherLeakSensor = this->create_publisher<std_msgs::msg::Bool>("/provider_dvl/dvl_leak_sensor", qos_pub_info);
+        _subscriptionEnableDisableDVL = this->create_subscription<std_msgs::msg::Bool>("/provider_dvl/enable_disable_dvl", qos_sub_info, std::bind(&PathfinderDVL::_enableDisableDVL, this, _1));
     }
 
     void PathfinderDVL::_enableDisableDVL(const std_msgs::msg::Bool &msg)

--- a/src/PathfinderDVL.cpp
+++ b/src/PathfinderDVL.cpp
@@ -19,6 +19,9 @@ namespace dvl_port_manager
         _publisherLeakSensor = this->create_publisher<std_msgs::msg::Bool>("/provider_dvl/dvl_leak_sensor", qos_pub_info);
         _subscriptionEnableDisableDVL = this->create_subscription<std_msgs::msg::Bool>("/provider_dvl/enable_disable_dvl", qos_sub_info, std::bind(&PathfinderDVL::_enableDisableDVL, this, _1));
     }
+    PathfinderDVL::~PathfinderDVL(){
+        
+    }
 
     void PathfinderDVL::_enableDisableDVL(const std_msgs::msg::Bool &msg)
     {

--- a/src/PathfinderDVL.cpp
+++ b/src/PathfinderDVL.cpp
@@ -8,8 +8,11 @@ namespace dvl_port_manager
     PathfinderDVL::PathfinderDVL()
         : DVLProvider("192.168.0.32", 1033, 1035, sizeof(PathfinderFormat_t))
     {
-        _publisherBodyVelocity = this->create_publisher<sonia_common_ros2::msg::BodyVelocityDVL>("/provider_dvl/dvl_velocity", 10);
-        _publisherLeakSensor = this->create_publisher<std_msgs::msg::Bool>("/provider_dvl/dvl_leak_sensor", 10);
+        rclcpp::QoS qos(10);
+        qos.reliable();
+
+        _publisherBodyVelocity = this->create_publisher<sonia_common_ros2::msg::BodyVelocityDVL>("/provider_dvl/dvl_velocity", qos);
+        _publisherLeakSensor = this->create_publisher<std_msgs::msg::Bool>("/provider_dvl/dvl_leak_sensor", qos);
         _subscriptionEnableDisableDVL = this->create_subscription<std_msgs::msg::Bool>("/provider_dvl/enable_disable_dvl", 10, std::bind(&PathfinderDVL::_enableDisableDVL, this, _1));
     }
 

--- a/src/PathfinderDVL.cpp
+++ b/src/PathfinderDVL.cpp
@@ -10,7 +10,7 @@ namespace dvl_port_manager
     {
         //Setting Quality of service policy
         rclcpp::QoS qos_pub_info(10);
-        qos_pub_info.reliability(rclcpp::ReliabilityPolicy::BestEffort);
+        qos_pub_info.reliability(rclcpp::ReliabilityPolicy::Reliable);
 
         rclcpp::QoS qos_sub_info(1);
         qos_sub_info.reliability(rclcpp::ReliabilityPolicy::Reliable);


### PR DESCRIPTION
- Qos policy added for publishers
   went for Best Effort, Volatile, KeepLast
- for AUV8, added one more for subscription
    went for reliable, transient local
NOTE: all subcritions/publishers to the mentionned topics have to match the QoS